### PR TITLE
Update MCPing and MCQuery to allow for proper extension

### DIFF
--- a/src/MCPing.php
+++ b/src/MCPing.php
@@ -17,7 +17,7 @@ class MCPing {
 	private static $timeout;
 	private static $response;
 	
-	private function __construct() {
+	protected function __construct() {
 	}
 	
 	/**

--- a/src/MCQuery.php
+++ b/src/MCQuery.php
@@ -16,7 +16,7 @@ class MCQuery {
 	private static $handshake = 0x09;
 	private static $socket;
 	
-	private function __construct() {
+	protected function __construct() {
 	}
 	
 	/**


### PR DESCRIPTION
Currently the constructor for both MCPing and MCQuery are private which disallows calling it as a parent constructor. While the constructor is technically not required in this case, it is still best practice to call it from within the child class, thus I propose this change.